### PR TITLE
Implement models for DAODAO + some small changes for consistency

### DIFF
--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/strangelove-ventures/valis/indexer"
+	"github.com/strangelove-ventures/valis/indexer/actions/daodao"
 	"github.com/strangelove-ventures/valis/indexer/actions/ibc"
 	"go.uber.org/zap"
 )
@@ -17,6 +18,8 @@ func (c *Config) GetBlockActionByName(log *zap.Logger, name string) (indexer.Blo
 	switch name {
 	case ibc.BlockActionName:
 		return ibc.NewIBCTransfer(log.With(zap.String("block_action", ibc.BlockActionName))), nil
+	case daodao.BlockActionName:
+		return daodao.NewDAODAOAction(log.With(zap.String("block_action", daodao.BlockActionName))), nil
 	default:
 		return nil, fmt.Errorf("there is no block action configured with the name %s", name)
 	}

--- a/indexer/actions/daodao/daodao.go
+++ b/indexer/actions/daodao/daodao.go
@@ -1,0 +1,146 @@
+package daodao
+
+import (
+	"context"
+	"encoding/hex"
+	"time"
+
+	cosmwasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/strangelove-ventures/valis/indexer"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
+	"go.uber.org/zap"
+)
+
+// BlockActionName is used for configuring block actions via the config file,
+// these names are read when starting the indexer for building the list of actions to take at runtime.
+const BlockActionName = "daodao"
+
+// DAODAOAction implements the indexer.BlockAction interface, it describes the appropriate actions to take in order
+// to parse the DAODAO smart contract data on-chain and index it into a database instance.
+type DAODAOAction struct {
+	actionName string
+	log        *zap.Logger
+}
+
+// NewDAODAOAction returns a new DAODAOAction block action to be used by the indexer.
+func NewDAODAOAction(log *zap.Logger) *DAODAOAction {
+	return &DAODAOAction{
+		actionName: BlockActionName,
+		log:        log,
+	}
+}
+
+// Name returns the block action name for identifying this action.
+func (a *DAODAOAction) Name() string {
+	return a.actionName
+}
+
+// MigrateSchema runs schema migrations for the specified models.
+func (a *DAODAOAction) MigrateSchema(indexer *indexer.Indexer) error {
+	return indexer.DB.AutoMigrate(
+		&Code{},
+		&Contract{},
+		&ExecMsg{},
+		&CW20Balance{},
+		&CW20Transaction{},
+		&Coin{},
+		&DAO{},
+		&Marketing{},
+		&GovToken{},
+		&Logo{},
+	)
+}
+
+// Execute calls the appropriate functions needed for properly parsing data related to the DAODAO smart contracts.
+func (a *DAODAOAction) Execute(ctx context.Context, indexer *indexer.Indexer, block *coretypes.ResultBlock) error {
+	return a.IndexDAODAOContracts(ctx, indexer, block)
+}
+
+// IndexDAODAOContracts parses the tx data in the specified block and indexes the tx data along with
+// and DAODAO smart contract related data into a postgres database instance.
+func (a *DAODAOAction) IndexDAODAOContracts(ctx context.Context, indexer *indexer.Indexer, block *coretypes.ResultBlock) error {
+	for index, tx := range block.Block.Data.Txs {
+		// Check if the context has been cancelled on each iteration
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Millisecond * 100):
+			// continue
+		}
+
+		sdkTx, err := indexer.Client.Codec.TxConfig.TxDecoder()(tx)
+		if err != nil {
+			a.log.Debug(
+				"Failed to decode tx",
+				zap.Int64("height", block.Block.Height),
+				zap.Int("tx_index", index+1),
+				zap.Int("total_txs", len(block.Block.Data.Txs)),
+				zap.Error(err),
+			)
+
+			// TODO we may want to keep track of txs that fail to be decoded or do something besides log the error
+			continue
+		}
+
+		// TODO This can fail so results may not end up in db
+		// ex. Failed to query tx results. Err: failed to read response body: context deadline exceeded (Client.Timeout or context cancellation while reading body)
+		// ex. [Height 2301720] {8/9 txs} - Failed to query tx results. Err: post failed: Post "https://rpc-juno.ecostake.com:443": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+		txRes, err := indexer.Client.QueryTx(ctx, hex.EncodeToString(tx.Hash()), true)
+		if err != nil {
+			a.log.Debug(
+				"Failed to query tx results",
+				zap.Int64("height", block.Block.Height),
+				zap.Int("tx_index", index+1),
+				zap.Int("total_txs", len(block.Block.Data.Txs)),
+				zap.Error(err),
+			)
+
+			// TODO we may want to retry or keep track of txs that fail to be queried
+			continue
+		}
+
+		// TODO remove these, just here to kill compiler errors
+		_ = txRes
+
+		for msgIndex, msg := range sdkTx.GetMsgs() {
+			a.HandleMsgs(indexer, msg, msgIndex, block.Block.Height, tx.Hash())
+		}
+	}
+	return nil
+}
+
+func (a *DAODAOAction) HandleMsgs(indexer *indexer.Indexer, msg sdk.Msg, msgIndex int, height int64, hash []byte) {
+	switch m := msg.(type) {
+	case *cosmwasmtypes.MsgExecuteContract:
+		// do te thing
+		a.log.Info(
+			"RawMsg",
+			zap.String("msg", string(m.Msg.Bytes())),
+		)
+	case *cosmwasmtypes.MsgInstantiateContract:
+		// do te thing
+		a.log.Info(
+			"RawMsg",
+			zap.String("msg", string(m.Msg.Bytes())),
+		)
+	case *cosmwasmtypes.MsgMigrateContract:
+		// do te thing
+		a.log.Info(
+			"RawMsg",
+			zap.String("msg", string(m.Msg.Bytes())),
+		)
+	case *cosmwasmtypes.MsgStoreCode:
+		// do te thing
+		a.log.Info(
+			"RawMsg",
+			zap.String("msg", string(m.WASMByteCode)),
+		)
+	case *cosmwasmtypes.MsgUpdateAdmin:
+		// do te thing
+		a.log.Info(
+			"RawMsg",
+			zap.String("msg", m.Contract),
+		)
+	}
+}

--- a/indexer/actions/daodao/daodao_models.go
+++ b/indexer/actions/daodao/daodao_models.go
@@ -1,0 +1,91 @@
+package daodao
+
+import (
+	"time"
+
+	"github.com/jackc/pgtype"
+)
+
+type Code struct {
+	ID           int64     `gorm:"primaryKey;autoIncrement:false"`
+	Height       int64     `gorm:"not null"`
+	Creator      string    `gorm:"not null;default:''"`
+	CreationTime time.Time `gorm:"not null"`
+
+	Contract Contract `gorm:"foreignKey:CodeID;references:ID"`
+}
+
+type Contract struct {
+	Address                string    `gorm:"primaryKey"`
+	StakingContractAddress string    `gorm:"not null"`
+	CodeID                 int64     `gorm:"not null"`
+	Creator                string    `gorm:"not null;default:''"`
+	Admin                  string    `gorm:"not null;default:''"`
+	Label                  string    `gorm:"not null;default:''"`
+	CreationTime           time.Time `gorm:"not null"`
+	Height                 int64     `gorm:"not null"`
+
+	DAO DAO `gorm:"foreignKey:ContractAddress;references:Address"`
+}
+
+type ExecMsg struct {
+	ID      int
+	Sender  string `gorm:"not null"`
+	Address string `gorm:"not null"`
+}
+
+type CW20Balance struct {
+	ID      int
+	Address string `gorm:"not null"`
+	Token   string `gorm:"not null"`
+	Balance int64  `gorm:"not null"`
+}
+
+type CW20Transaction struct {
+	ID               int
+	CW20Address      string `gorm:"not null"`
+	SenderAddress    string `gorm:"not null"`
+	RecipientAddress string `gorm:"not null"`
+	Amount           int64  `gorm:"not null"`
+	Height           int64  `gorm:"not null"`
+}
+
+type Coin struct {
+	ID int
+}
+
+type DAO struct {
+	ID                     int
+	ContractAddress        string `gorm:"not null"`
+	StakingContractAddress string `gorm:"not null"`
+	Name                   string `gorm:"not null"`
+	Description            string `gorm:"not null"`
+	ImageURL               string
+	GovTokenID             int `gorm:"not null"`
+}
+
+type Marketing struct {
+	ID            int
+	Project       string
+	Description   string
+	MarketingText string
+	LogoID        int
+
+	GovToken GovToken `gorm:"foreignKey:MarketingID;references:ID"`
+}
+
+type GovToken struct {
+	ID          int
+	Address     string `gorm:"not null"`
+	Name        string `gorm:"not null"`
+	Symbol      string `gorm:"not null"`
+	Decimals    int
+	MarketingID int
+}
+
+type Logo struct {
+	ID  int
+	URL string
+	SVG string
+	PNG pgtype.Bytea
+}

--- a/indexer/actions/ibc/ibc_models.go
+++ b/indexer/actions/ibc/ibc_models.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgtype"
-	"github.com/strangelove-ventures/valis/indexer"
 )
 
 // Tx represents a single tx, which can contain many messages.
@@ -73,19 +72,8 @@ type MsgTimeout struct {
 	DstPort    string       `gorm:"not null"`
 }
 
-// MigrateSchema runs schema migrations for the specified models.
-func (a *IBCTransfer) MigrateSchema(indexer *indexer.Indexer) error {
-	return indexer.DB.AutoMigrate(
-		&Tx{},
-		&MsgTransfer{},
-		&MsgRecvPacket{},
-		&MsgAcknowledgement{},
-		&MsgTimeout{},
-	)
-}
-
 /*
-func (a *IBCTransfer) GetLastStoredBlock(indexer *indexer.Indexer, chainId string) (int64, error) {
+func (a *IBCTransferAction) GetLastStoredBlock(indexer *indexer.Indexer, chainId string) (int64, error) {
 	var height int64
 	if err := indexer.DB.QueryRow("SELECT MAX(block_height) FROM txs WHERE chainid=$1", chainId).Scan(&height); err != nil {
 		return 1, err


### PR DESCRIPTION
Implemented the models for indexing DAODAO related contracts/data. These follow closely to the schemas defined by the team working on the Rust indexer but there are some key differences. These will likely be revised over time but this is a good starting point.

I also fleshed out the basic logic for crawling blocks and parsing txs on Juno.  Handling the Msg types still needs to be implemented.

Closes #6 